### PR TITLE
Version 3.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Billmate Payment Gateway for WooCommerce
+#Billmate Payment Gateway for WooCommerce
 By Billmate AB - [https://billmate.se](https://billmate.se/ "billmate.se")
 
 ## Documentation
@@ -46,14 +46,17 @@ Copy the code below for the size that fits your needs.
 
 ### Large
 <a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_l.png" alt="Billmate Payment Gateway" /></a>
+
 `<a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_l.png" alt="Billmate Payment Gateway" /></a>`
 
 ### Medium
 <a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_m.png" alt="Billmate Payment Gateway" /></a>
+
 `<a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_m.png" alt="Billmate Payment Gateway" /></a>`
 
 ### Small
 <a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_s.png" alt="Billmate Payment Gateway" /></a>
+
 `<a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_s.png" alt="Billmate Payment Gateway" /></a>`
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ By Billmate AB - [https://billmate.se](https://billmate.se/ "billmate.se")
 [Installation manual in Swedish](https://billmate.se/plugins/manual/Installationsmanual_Woocommerce_Billmate.pdf)
 
 ## Description 
-Billmate Gateway is a payment plugin for WooCommerce that gives your customers the abilty to pay with their favourite payment options. This plugin supports the WooCommerce standard checkout as well as the improved checkout experience that Billmate Checkout brings. Billmate Checkout integrates via a iframe soloution. 
+Billmate Gateway is a payment plugin for WooCommerce that gives your customers the ability to pay with their favorite payment options. This plugin supports the WooCommerce standard checkout as well as the improved checkout experience that Billmate Checkout brings. Billmate Checkout integrates via a iframe solution.
 
 ## Available payment methods
 * Invoice
@@ -16,7 +16,7 @@ Billmate Gateway is a payment plugin for WooCommerce that gives your customers t
 * Bank (Direct Bank payment through [Trustly](https://www.trustly.com))
 
 ## Important note
-The invoice and part payment plugin only works if the currency is set to Swedish Krona (SEK) and the Base country is set to Sweden.
+The invoice and part payment plugin only work if the currency is set to Swedish Krona (SEK) and the Base country is set to Sweden.
 
 ## Compatibility WordPress versions
 4.5.4 - 4.9.1
@@ -25,7 +25,7 @@ The invoice and part payment plugin only works if the currency is set to Swedish
 2.5.5 - 3.2.6
 
 ## Installation
-The simplest way to install this module is through the Wordpress Plugin Directory. However if you want to install manually, follow the steps below-
+The simplest way to install this module is through the WordPress Plugin Directory. However, if you want to install manually, follow the steps below-
 1. Download and unzip the latest release zip file.
 2. If you use the WordPress plugin uploader to install this plugin skip to step 4.
 3. Upload the entire plugin directory to your /wp-content/plugins/ directory.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Billmate Payment Gateway for WooCommerce
 By Billmate AB - [https://billmate.se](https://billmate.se/ "billmate.se")
 
-Original code created by Niklas Högefjord - http://krokedil.com/
-
 ## Documentation
 [Installation manual in English](https://billmate.se/plugins/manual/Installation_Manual_Woocommerce_Billmate.pdf)
 
@@ -20,13 +18,13 @@ Billmate is a great payment alternative for merchants and customers in Sweden.
 The invoice and part payment plugin only works if the currency is set to Swedish Krona (SEK) and the Base country is set to Sweden.
 
 ## COMPATIBILITY WordPress versions
-4.5.4 - 4.7
+4.5.4 - 4.9.1
 
 ## COMPATIBILITY WooCommerce versions
-2.5.5 - 3.0.6
+2.5.5 - 3.2.6
 
 ## COMPATIBILITY WooCommerce checkout
-* WooCommerce default checkout 2.5.5 - 3.0.6
+* WooCommerce default checkout 2.5.5 - 3.2.6
 
 ## Installation
 1. Download and unzip the latest release zip file.
@@ -44,182 +42,19 @@ You need to make sure our callback IP, 54.194.217.63, is whitelisted  in Wordfen
 Copy the code below for the size that fits your needs.
 
 ### Large
-
 <a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_l.png" alt="Billmate Payment Gateway" /></a>
-
 `<a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_l.png" alt="Billmate Payment Gateway" /></a>`
 
 ### Medium
-
 <a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_m.png" alt="Billmate Payment Gateway" /></a>
-
 `<a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_m.png" alt="Billmate Payment Gateway" /></a>`
 
 ### Small
-
 <a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_s.png" alt="Billmate Payment Gateway" /></a>
-
 `<a href="https://billmate.se"><img src="https://billmate.se/billmate/logos/billmate_cloud_s.png" alt="Billmate Payment Gateway" /></a>`
 
 ## Testing
 Tested with [Browserstack](http://www.browserstack.com)
 
-## Changelog
-
-### 3.0.1 (2017-05-16)
-* Fix - Improve compatibility with WC 3
-* Fix - Improve compatibility with PHP 7
-* Fix - Improve Billmate Checkout
-
-### 3.0 (2017-04-24)
-* Feature - Add support for Billmate Checkout
-* Fix - Prevent admin menu would be affected
-* Fix - Prevent handling fee added as order item
-
-### 2.2.11 (2017-01-03)
-* Fix - New Years issue with update payment plans.
-* Fix - Payment link issue invoice and partpay.
-
-### 2.2.10 (2016-12-21)
-* Fix - Abort payment, then do a new with same method.
-
-### 2.2.9 (2016-12-14)
-* Fix - Adjust som styling in checkout for smaller devices
-* Enhancement - Add product option to order
-* Enhancement - Add additional fees to order as products
-
-### 2.2.8 (2016-11-18)
-* Fix - Get address support for IE8 IE9
-* Enhancement - Display message in checkout when cancel/fail cardpayment
-* Enhancement - Display message in checkout when cancel/fail bankpayment
-* Enhancement - Links to manual in settings
-* Enhancement - Button to reset Pclasses in settings
-
-### 2.2.7 (2016-08-05)
-* Fix - Discount and VAT.
-
-### 2.2.6 (2016-04-07)
-* Fix - Address popup utf8.
-* Enhancement - Not send in zero fees.
-* Enhancement - Fixed some rounding issues.
-
-### 2.2.5 (2016-03-21)
-* Fix - Not send in Payment terms.
-
-### 2.2.4 (2016-02-29)
-* Fix - Subscriptions
-* Fix - Status for subscriptions.
-
-### 2.2.3 (2016-02-25)
-* Fix - Callback with post.
-
-### 2.2.2 (2016-02-16)  
-* Fix - Exit after all redirects.
-
-### 2.2.1 (2016-02-12)
-* Fix - Recurring number on order. 
-
-### 2.2 (2016-01-08)
-* Enhancement - Autoactivate invoices on complete.
-* Enhancement - Compatibility with Woocommerce Subscription. Recurring payment.
-* Translation - Improved the translations.
-* Enhancement - Update totals on getAddress click.
-* Engancement - Better tracking of invoices in order history.
-
-### 2.1.7(2016-01-21)
-* Fix - Rounding totals.
-
-### 2.1.6(2015-12-10)
-* Fix - Customer Nr.
-* Fix - Compatibility wc_seq_order_number.
-
-### 2.1.5 (2015-12-09)
-* Fix - Rounding.
-* Fix - Callback issue.
-
-### 2.1.4 (2015-10-29)
-* Fix - Fix bank and partpayment calculations.
-* Enhancement - Change classname from Encoding to BillmateStringEncoding, compatibility with Duplicator Pro plugin.
-
-### 2.1.3 (2015-10-12)
-* Fix - Php 5.4 compatibility, activate plugin issue.
-
-### 2.1.2 (2015-10-07)
-* Fix - Activate plugin issue.
-* Enhancement - Added filters for our icons.
-
-### 2.1.1 (2015-10-05)
-* Fix - UTF-8 encoding, payment denied message and Card and Bank payment addresses.
-* Fix - Rounding calculations.
-
-### 2.1 (2015-10-01)
-* Enhancement - Possibility to Choose logo on the invoice created in Billmate Online.
-* Optimization - Less load time when show partpayment from on product/shop page.
-* Enhancement - Communication error messages.
-* Fix - Cancel callback.
-
-### 2.0.6.2 (2015-09-25)
-* Fix - Callback issue with GET setting
-* Fix - Terms for invoice
-* Fix - Sequential Order number compatibility
-
-### 2.0.6 (2015-09-04)
-2 commits
-
-* Fix - Order status when order is denied.
-* Fix - Order note when order is denied.
-
-### 2.0.5 (2015-09-04)
-2 commits
-* Fix - Added transaction method on card again.
-
-### 2.0.4 (2015-08-24)
-2 commits
-* Enchancement - Prettified if no email is input in invoice and partpayment.
-* Fix - Order status Issue with partpayment and invoice.
-
-### 2.0.3 (2015-08-17)
-1 commit 2 issues closed.
-
-* Enchangement - Clean up logging.
-* Fix - Same encoding on all error messages.
-
-### 2.0.2 (2015-08-14)
-1 commit
-
-* Fix - Corrected a typo.
-
-### 2.0.1 (2015-08-13)
-1 commit
-* Compatibility - WooCommerce above 2.4
-
-### 2.0 (2015-08-05)
-110 commits and 79 issues closed.
-
-* Compatibility - WooCommerce 2.0 and above.
-* Enchancement - Get Address for customers in the Checkout.
-* Tweak - Layout improvements.
-* Tweak - Automatic update of paymentplans.
-* Tweak - Clearify Invoice fee in Invoice payment title.
-* Tweak - Validation of Billmate Credentials.
-* Tweak - Can choose status of payment.
-* Tweak - Remove need of product for the Invoice Fee.
-* Fix - Consequent display of testmode.
-* Fix - Added better support for plugin dynamic pricing.
-* Fix - Discount is now divided per Vat rate.
-* Fix - Can now order when create account on checkout.
-
-### 1.23.2 (2015-01-30)
-* Fix - Fixed a bug that if you entered a matching adress, the verification of the adress popup still appeared.
-
-### 1.23.1 (2015-01-19)
-* Fix - The payment status is set to the correct on all payment methods.
-
-### 1.23 (2015-01-08)
-* Feature - Added the functionality so that if you put a file called billmatecustom.css in the plugin it will include that. Useful if you need to overwrite some CSS to make the Billmate plugin look good in you checkout without everwriting the themes css.
-* Fix - Fixed so that an error on the checkout page does not occur if you enter wrong "personnummer" twice.
-* Fix - If you enter a wroong ID for the invoice fee the checkout and settings page does not crash.
-* Fix - Removed references to WPLANG and now uses get_locale function instead. According to Wordpres coding standard.
-* Tweak - Updated to new company name : Billmate AB.
-* Tweak - Change to correct include of colorbox.css to follow Wordpress coding standard
-* Tweak - Fixed so that partpayment prices is shown as 12 mounths instead of 3
+---
+Original code created by Niklas Högefjord - http://krokedil.com/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The simplest way to install this module is through the WordPress Plugin Director
 ## Can I use Wordfence or any other Firewall plugin?
 You need to make sure our callback IP, 54.194.217.63, is whitelisted  in Wordfence. Navigate to "Wordfence -> Options" and scroll down to "Other Options". Add our ip-number next to "Whitelisted IP addresses that bypass all rules" and it should work. If not, please contact our support, support@billmate.se.
 
+## Verified compatible external plugins
+* [WooCommerce Subsciption](https://woocommerce.com/products/woocommerce-subscriptions/ "WooCommerce Subsciption")
+* [Product Add-Ons](https://woocommerce.com/products/product-add-ons/ "Product Add-Ons")
+
 ## How to place Billmate logo on your site.
 Copy the code below for the size that fits your needs.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The simplest way to install this module is through the WordPress Plugin Director
 You need to make sure our callback IP, 54.194.217.63, is whitelisted  in Wordfence. Navigate to "Wordfence -> Options" and scroll down to "Other Options". Add our ip-number next to "Whitelisted IP addresses that bypass all rules" and it should work. If not, please contact our support, support@billmate.se.
 
 ## Verified compatible external plugins
-* [WooCommerce Subsciption](https://woocommerce.com/products/woocommerce-subscriptions/ "WooCommerce Subsciption")
+* [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/ "WooCommerce Subscriptions")
 * [Product Add-Ons](https://woocommerce.com/products/product-add-ons/ "Product Add-Ons")
 
 ## How to place Billmate logo on your site.

--- a/README.md
+++ b/README.md
@@ -6,27 +6,26 @@ By Billmate AB - [https://billmate.se](https://billmate.se/ "billmate.se")
 
 [Installation manual in Swedish](https://billmate.se/plugins/manual/Installationsmanual_Woocommerce_Billmate.pdf)
 
-## Description
-Billmate Gateway is a plugin that extends WooCommerce, allowing your customers to get their products first and pay by invoice to Billmate later (https://billmate.se/). This plugin utilizes Billmate Invoice, Billmate Card, Billmate Bank and Billmate Part Payment (Standard Integration type).
+## Description 
+Billmate Gateway is a payment plugin for WooCommerce that gives your customers the abilty to pay with their favourite payment options. This plugin supports the WooCommerce standard checkout as well as the improved checkout experience that Billmate Checkout brings. Billmate Checkout integrates via a iframe soloution. 
 
-When the order is passed to Billmate a credit record of the customer is made. If the check turns out all right, Billmate creates an invoice in their system. After you (as the merchant) completes the order in WooCommerce, you need to log in to Billmate to approve/send the invoice.
-
-Billmate is a great payment alternative for merchants and customers in Sweden.
-
+## Available payment methods
+* Invoice
+* Part payment
+* Card
+* Bank (Direct Bank payment through [Trustly](https://www.trustly.com))
 
 ## Important note
 The invoice and part payment plugin only works if the currency is set to Swedish Krona (SEK) and the Base country is set to Sweden.
 
-## COMPATIBILITY WordPress versions
+## Compatibility WordPress versions
 4.5.4 - 4.9.1
 
-## COMPATIBILITY WooCommerce versions
+## Compatibility WooCommerce versions
 2.5.5 - 3.2.6
 
-## COMPATIBILITY WooCommerce checkout
-* WooCommerce default checkout 2.5.5 - 3.2.6
-
 ## Installation
+The simplest way to install this module is through the Wordpress Plugin Directory. However if you want to install manually, follow the steps below-
 1. Download and unzip the latest release zip file.
 2. If you use the WordPress plugin uploader to install this plugin skip to step 4.
 3. Upload the entire plugin directory to your /wp-content/plugins/ directory.
@@ -35,8 +34,8 @@ The invoice and part payment plugin only works if the currency is set to Swedish
 6. Go to --> WooCommerce --> Settings --> Payment Gateways and configure your Billmate settings.
 7. Billmate Part Payment: Click the button "Update paymentplans" on the settings page to fetch your shops PClasses and store them in the database.
 
-## Can I use Wordfence or other Firewall plugin?
-You need to make sure our callback IP, 54.194.217.63, is whitelisted  in Wordfence. Navigate to "Wordfence -> Options" and scroll down to "Other Options". Add our ip-number next to "Whitelisted IP addresses that bypass all rules" and it should go.
+## Can I use Wordfence or any other Firewall plugin?
+You need to make sure our callback IP, 54.194.217.63, is whitelisted  in Wordfence. Navigate to "Wordfence -> Options" and scroll down to "Other Options". Add our ip-number next to "Whitelisted IP addresses that bypass all rules" and it should work. If not, please contact our support, support@billmate.se.
 
 ## How to place Billmate logo on your site.
 Copy the code below for the size that fits your needs.

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 * Fix - Bank payments now always use the same string where it's referenced.
 * Fix - Rounding improvements. Under some rare circumstances the amount can be different from payment window to callback and/or accept url. 
 * Enhancement - Improved loading animation for Checkout - The loading animation is more precise triggered when needed.
-* Feature - Support for plugin "Procut Add-Ons" in combination with Billmate Checkout.
+* Feature - Support for plugin "Product Add-Ons" in combination with Billmate Checkout.
 
 ## 3.1.0 (2017-12-19)
 * Fix - BC add handling fee on store order when set orderstatus is not default

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.1 (2018-01-29)
+* Fix - Bank payments now always use the same string where it's referenced.
+* Fix - Rounding improvements. Under some rare circumstances the amount can be different from payment window to callback and/or accept url. 
+* Enhancement - Improved loading animation for Checkout - The loading animation is more precise triggered when needed.
+* Feature - Support for plugin "Procut Add-Ons" in combination with Billmate Checkout.
+
 ## 3.1.0 (2017-12-19)
 * Fix - BC add handling fee on store order when set orderstatus is not default
 * Fix - BC support for autoactivate order on creation

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 3.1.0 (2017-12-19)
+* Fix - BC add handling fee on store order when set orderstatus is not default
+* Fix - BC support for autoactivate order on creation
+* Fix - Tax calculation when free shipping
+* Enhancement - Improve rounding accuracy for prices set including tax and zero decimals
+* Enhancement - WooCommerce subscription support for change card information and manually pay failed subscription order
+* Enhancement - Invoice fee support for WPML currency
+* Enhancement - Improve shipping tax calculation
+* Enhancement - Replace Cardpayment logo
+
+
+## 3.0.8 (2017-10-10)
+* Fix - Fix order completed when not paid with Billmate
+
+## 3.0.7 (2017-10-09)
+* Fix - Add missing handling fee on order paid with checkout and rely on callback
+* Enhancement - Use method 2 if 1 is unavailable
+* Fix - handle shipping with no tax
+* Enhancement - Prevent cache of checkout page
+* Enhancement - Improve error messages on order note if order activation not success
+* Enhancement - Change order of getAddress to be done after try first with addPayment
+* Fix - Add handling fee to store order when pay_for_order isset
+* Fix - Display partpayment info on product page once
+
+## 3.0.6 (2017-09-14)
+* Improve - Improve the selected currency check when display payment methods
+* Improve - Support for additional get parameters
+* Improve - Support for activate Billmate Checkout invoice on callback
+
+## 3.0.5 (2017-07-28)
+* Fix - Improve Billmate Checkout speed and communication
+
+## 3.0.4 (2017-07-15)
+* Fix - WooCommerce Subscription 2.2.8 compatibility
+* Enhancement - Add links in plugin list
+
+## 3.0.3 (2017-06-12)
+* Fix - Support discount 12% vat
+* Enhancement - Discount can be on item level or order level
+* Enhancement - Use order item name if standard product
+
+## 3.0.2 (2017-06-07)
+* Fix - Improve compatibility with WC 3
+* Fix - Improve Billmate Checkout
+
 ## 3.0.1 (2017-05-16)
 * Fix - Improve compatibility with WC 3
 * Fix - Improve compatibility with PHP 7

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,158 @@
+# Changelog
+
+## 3.0.1 (2017-05-16)
+* Fix - Improve compatibility with WC 3
+* Fix - Improve compatibility with PHP 7
+* Fix - Improve Billmate Checkout
+
+## 3.0 (2017-04-24)
+* Feature - Add support for Billmate Checkout
+* Fix - Prevent admin menu would be affected
+* Fix - Prevent handling fee added as order item
+
+## 2.2.11 (2017-01-03)
+* Fix - New Years issue with update payment plans.
+* Fix - Payment link issue invoice and partpay.
+
+## 2.2.10 (2016-12-21)
+* Fix - Abort payment, then do a new with same method.
+
+## 2.2.9 (2016-12-14)
+* Fix - Adjust som styling in checkout for smaller devices
+* Enhancement - Add product option to order
+* Enhancement - Add additional fees to order as products
+
+## 2.2.8 (2016-11-18)
+* Fix - Get address support for IE8 IE9
+* Enhancement - Display message in checkout when cancel/fail cardpayment
+* Enhancement - Display message in checkout when cancel/fail bankpayment
+* Enhancement - Links to manual in settings
+* Enhancement - Button to reset Pclasses in settings
+
+## 2.2.7 (2016-08-05)
+* Fix - Discount and VAT.
+
+## 2.2.6 (2016-04-07)
+* Fix - Address popup utf8.
+* Enhancement - Not send in zero fees.
+* Enhancement - Fixed some rounding issues.
+
+## 2.2.5 (2016-03-21)
+* Fix - Not send in Payment terms.
+
+## 2.2.4 (2016-02-29)
+* Fix - Subscriptions
+* Fix - Status for subscriptions.
+
+## 2.2.3 (2016-02-25)
+* Fix - Callback with post.
+
+## 2.2.2 (2016-02-16)  
+* Fix - Exit after all redirects.
+
+## 2.2.1 (2016-02-12)
+* Fix - Recurring number on order. 
+
+## 2.2 (2016-01-08)
+* Enhancement - Autoactivate invoices on complete.
+* Enhancement - Compatibility with Woocommerce Subscription. Recurring payment.
+* Translation - Improved the translations.
+* Enhancement - Update totals on getAddress click.
+* Engancement - Better tracking of invoices in order history.
+
+## 2.1.7(2016-01-21)
+* Fix - Rounding totals.
+
+## 2.1.6(2015-12-10)
+* Fix - Customer Nr.
+* Fix - Compatibility wc_seq_order_number.
+
+## 2.1.5 (2015-12-09)
+* Fix - Rounding.
+* Fix - Callback issue.
+
+## 2.1.4 (2015-10-29)
+* Fix - Fix bank and partpayment calculations.
+* Enhancement - Change classname from Encoding to BillmateStringEncoding, compatibility with Duplicator Pro plugin.
+
+## 2.1.3 (2015-10-12)
+* Fix - Php 5.4 compatibility, activate plugin issue.
+
+## 2.1.2 (2015-10-07)
+* Fix - Activate plugin issue.
+* Enhancement - Added filters for our icons.
+
+## 2.1.1 (2015-10-05)
+* Fix - UTF-8 encoding, payment denied message and Card and Bank payment addresses.
+* Fix - Rounding calculations.
+
+## 2.1 (2015-10-01)
+* Enhancement - Possibility to Choose logo on the invoice created in Billmate Online.
+* Optimization - Less load time when show partpayment from on product/shop page.
+* Enhancement - Communication error messages.
+* Fix - Cancel callback.
+
+## 2.0.6.2 (2015-09-25)
+* Fix - Callback issue with GET setting
+* Fix - Terms for invoice
+* Fix - Sequential Order number compatibility
+
+## 2.0.6 (2015-09-04)
+2 commits
+* Fix - Order status when order is denied.
+* Fix - Order note when order is denied.
+
+## 2.0.5 (2015-09-04)
+2 commits
+* Fix - Added transaction method on card again.
+
+## 2.0.4 (2015-08-24)
+2 commits
+* Enchancement - Prettified if no email is input in invoice and partpayment.
+* Fix - Order status Issue with partpayment and invoice.
+
+## 2.0.3 (2015-08-17)
+1 commit 2 issues closed.
+* Enchangement - Clean up logging.
+* Fix - Same encoding on all error messages.
+
+## 2.0.2 (2015-08-14)
+1 commit
+* Fix - Corrected a typo.
+
+## 2.0.1 (2015-08-13)
+1 commit
+* Compatibility - WooCommerce above 2.4
+
+## 2.0 (2015-08-05)
+110 commits and 79 issues closed.
+* Compatibility - WooCommerce 2.0 and above.
+* Enchancement - Get Address for customers in the Checkout.
+* Tweak - Layout improvements.
+* Tweak - Automatic update of paymentplans.
+* Tweak - Clearify Invoice fee in Invoice payment title.
+* Tweak - Validation of Billmate Credentials.
+* Tweak - Can choose status of payment.
+* Tweak - Remove need of product for the Invoice Fee.
+* Fix - Consequent display of testmode.
+* Fix - Added better support for plugin dynamic pricing.
+* Fix - Discount is now divided per Vat rate.
+* Fix - Can now order when create account on checkout.
+
+## 1.23.2 (2015-01-30)
+* Fix - Fixed a bug that if you entered a matching adress, the verification of the adress popup still appeared.
+
+## 1.23.1 (2015-01-19)
+* Fix - The payment status is set to the correct on all payment methods.
+
+## 1.23 (2015-01-08)
+* Feature - Added the functionality so that if you put a file called billmatecustom.css in the plugin it will include that. Useful if you need to overwrite some CSS to make the Billmate plugin look good in you checkout without everwriting the themes css.
+* Fix - Fixed so that an error on the checkout page does not occur if you enter wrong "personnummer" twice.
+* Fix - If you enter a wroong ID for the invoice fee the checkout and settings page does not crash.
+* Fix - Removed references to WPLANG and now uses get_locale function instead. According to Wordpres coding standard.
+* Tweak - Updated to new company name : Billmate AB.
+* Tweak - Change to correct include of colorbox.css to follow Wordpress coding standard
+* Tweak - Fixed so that partpayment prices is shown as 12 mounths instead of 3
+
+---
+Original code created by Niklas Högefjord - http://krokedil.com/

--- a/woocommerce-gateway-billmate/Readme.txt
+++ b/woocommerce-gateway-billmate/Readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: woocomerce, billmate, payments, cardpayments, invoice, partpayment, recurring, bankpayment
 Requires at least: 4.0
 Tested up to: 4.9.1
-Stable tag: 3.1.0
+Stable tag: 3.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/woocommerce-gateway-billmate/billmatecheckout.css
+++ b/woocommerce-gateway-billmate/billmatecheckout.css
@@ -1,33 +1,3 @@
-.billmateoverlay {
-    background: #FFFFFF;
-    display: none;
-    height: 100vh;
-    left: 0;
-    opacity: 0.5;
-    padding-top: 49vh;
-    position: absolute;
-    top: 0px;
-    width: 100%;
-    z-index: 2;
-}
-
-.billmateloading {
-    -webkit-animation: spin 2s linear infinite;
-    animation: spin 2s linear infinite;
-    border: 5px solid rgba(0, 0, 0, 0);
-    border-radius: 50%;
-    border-right: 5px solid #0099D3;
-    border-top: 5px solid #0099D3;
-    display: none;
-    height: 100px;
-    left: 50%;
-    margin: -50px 0 0 -50px;
-    position: absolute;
-    top: 50%;
-    width: 100px;
-    z-index: 3;
-}
-
 .cart_totals{
     margin: 30px 0 50px 0
 }
@@ -36,17 +6,6 @@
 #checkoutdiv {
     position: relative;
     overflow: auto;
-}
-
-#checkoutdiv.loading {
-    overflow: hidden;
-}
-
-/* Anytime the body has the loading class, our
-   modal element will be visible */
-#checkoutdiv.loading .billmateoverlay,
-#checkoutdiv.loading .billmateloading {
-    display: block;
 }
 
 .wc-proceed-to-checkout {

--- a/woocommerce-gateway-billmate/class-billmate-bankpay.php
+++ b/woocommerce-gateway-billmate/class-billmate-bankpay.php
@@ -123,7 +123,7 @@ class WC_Gateway_Billmate_Bankpay extends WC_Gateway_Billmate {
         $config = array(
             'testmode' => $this->testmode,
             'method_id' => $this->id,
-            'method_title' => $this->method_title,
+            'method_title' => $this->title,
             'checkoutMessageCancel' => $checkoutMessageCancel,
             'checkoutMessageFail' => $checkoutMessageFail,
             'transientPrefix' => $transientPrefix,

--- a/woocommerce-gateway-billmate/class-billmate-cardpay.php
+++ b/woocommerce-gateway-billmate/class-billmate-cardpay.php
@@ -139,7 +139,7 @@ class WC_Gateway_Billmate_Cardpay extends WC_Gateway_Billmate {
         $config = array(
             'testmode' => $this->testmode,
             'method_id' => $this->id,
-            'method_title' => $this->method_title,
+            'method_title' => $this->title,
             'checkoutMessageCancel' => $checkoutMessageCancel,
             'checkoutMessageFail' => $checkoutMessageFail,
             'transientPrefix' => $transientPrefix,

--- a/woocommerce-gateway-billmate/class-billmate-checkout.php
+++ b/woocommerce-gateway-billmate/class-billmate-checkout.php
@@ -575,6 +575,15 @@ class WC_Gateway_Billmate_Checkout extends WC_Gateway_Billmate
         if(isset($order)){
             $order->remove_order_items();
 
+            /** WooCommerce >= 3.0 */
+            if (is_callable(array(WC()->checkout, 'create_order_line_items'))) {
+                $order_items = $order->get_items( array( 'line_item' ) );
+                if (empty($order_items)) {
+                    WC()->checkout->create_order_line_items($order, WC()->cart);
+                }
+            }
+
+            /** WooCommerce < 3.0 */
             $order_items = $order->get_items( array( 'line_item' ) );
             if ( empty( $order_items ) ) {
                 foreach ( WC()->cart->get_cart() as $key => $values ) {

--- a/woocommerce-gateway-billmate/commonfunctions.php
+++ b/woocommerce-gateway-billmate/commonfunctions.php
@@ -1209,6 +1209,8 @@ if(!class_exists('BillmateOrder')){
             /* Return articles and discout to be used in Billmate API requests */
             if(isset($this->orderData['Articles'])) {
                 return $this->orderData['Articles'];
+            } else {
+                $this->orderData['Articles'] = array();
             }
 
             /* Articles */

--- a/woocommerce-gateway-billmate/commonfunctions.php
+++ b/woocommerce-gateway-billmate/commonfunctions.php
@@ -1,5 +1,5 @@
 <?php
-define('BILLPLUGIN_VERSION','3.1.0');
+define('BILLPLUGIN_VERSION','3.1.1');
 define('BILLMATE_CLIENT','PHP:Woocommerce:'.BILLPLUGIN_VERSION);
 define('BILLMATE_SERVER','2.1.9');
 

--- a/woocommerce-gateway-billmate/gateway-billmate.php
+++ b/woocommerce-gateway-billmate/gateway-billmate.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce Billmate Gateway
 Plugin URI: http://woothemes.com/woocommerce
 Description: Receive payments on your WooCommerce store via Billmate. Invoice, partpayment, credit/debit card and direct bank transfers. Secure and 100&#37; free plugin.
-Version: 3.1.0
+Version: 3.1.1
 Author: Billmate
 Text Domain: billmate
 Author URI: https://billmate.se

--- a/woocommerce-gateway-billmate/gateway-billmate.php
+++ b/woocommerce-gateway-billmate/gateway-billmate.php
@@ -777,8 +777,10 @@ function init_billmate_gateway() {
                         $storeOrderTotalCompare     = intval( strval( $order->get_total() * 100 ) );
                         $billmateOrderTotalCompare  = intval($billmateOrderTotal);
 
-
-                        if ($storeOrderTotalCompare == $billmateOrderTotalCompare) {
+                        // Allow diff in case of store rounding
+                        if (    $storeOrderTotalCompare - 300 <= $billmateOrderTotalCompare
+                                && $storeOrderTotalCompare + 300 >= $billmateOrderTotalCompare
+                        ) {
                             // Set order as paid if paid amount matches order total amount
                             if ($this->order_status != 'default') {
                                 $order->update_status($this->order_status);
@@ -810,8 +812,8 @@ function init_billmate_gateway() {
                                 $floatCompare = round(floatval($compare), 2);
                                 $floatGettotal = round(floatval($order->get_total()), 2);
 
-
-                                if ($floatGettotal == $floatCompare) {
+                                // Allow diff in case of store rounding
+                                if ($floatGettotal - 3 <= $floatCompare && $floatGettotal + 3 >= $floatCompare) {
                                     // Assume handling fee is missing, add handling fee and mark order as paid
 
                                     // Handling fee tax rates

--- a/woocommerce-gateway-billmate/gateway-billmate.php
+++ b/woocommerce-gateway-billmate/gateway-billmate.php
@@ -737,14 +737,6 @@ function init_billmate_gateway() {
                                 if (isset($billmateOrder['PaymentData']['method'])) {
                                     $billmateOrderMethod = $billmateOrder['PaymentData']['method'];
                                 }
-
-                                if ( $billmateOrderMethod == '8' ) {
-                                    $_method_title = __('Billmate Cardpay', 'billmate');
-                                }
-
-                                if( $billmateOrderMethod == '16' ) {
-                                    $_method_title = __('Billmate Bank', 'billmate');
-                                }
                             }
 
                         }

--- a/woocommerce-gateway-billmate/js/billmatecheckout.js
+++ b/woocommerce-gateway-billmate/js/billmatecheckout.js
@@ -10,6 +10,7 @@ jQuery(document).ready(function(){
 var BillmateIframe = new function(){
     var self = this;
     var childWindow = null;
+    var timerPostMessage;
 
     this.updateAddress = function (data) {
         // When address in checkout updates;
@@ -183,11 +184,21 @@ var BillmateIframe = new function(){
     }
 
     this.lock = function() {
-        this.checkoutPostMessage('lock');
+        that = this;
+        clearTimeout(this.timerPostMessage);
+        var wait = setTimeout(function() {
+            that.checkoutPostMessage('lock');
+        }, 500);
+        this.timerPostMessage = wait;
     }
 
     this.unlock = function() {
-        this.checkoutPostMessage('unlock');
+        that = this;
+        clearTimeout(this.timerPostMessage);
+        var wait = setTimeout(function() {
+            that.checkoutPostMessage('unlock');
+        }, 500);
+        this.timerPostMessage = wait;
     }
 
     var showCheckoutLoadingCounter = 0;

--- a/woocommerce-gateway-billmate/js/billmatecheckout.js
+++ b/woocommerce-gateway-billmate/js/billmatecheckout.js
@@ -40,7 +40,6 @@ var BillmateIframe = new function(){
                 if(response.hasOwnProperty("success") && response.success) {
                     window.address_selected = true;
                 }
-                self.hideCheckoutLoading();
                 self.updateCheckout();
             }
         });
@@ -105,32 +104,25 @@ var BillmateIframe = new function(){
 
         /* Listen to WooCommerce checkout elements */
         jQuery(document).on('click', "input[name='update_cart']", function() {
-            jQuery('#checkoutdiv').addClass('loading');
-            jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
+            self.lock();
         });
         jQuery( document ).on('click', 'div.woocommerce > form input[type=submit]', function() {
-                jQuery('#checkoutdiv').addClass('loading');
-                jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
+            self.lock();
         });
         jQuery( document ).on('keypress', 'div.woocommerce > form input[type=number]', function() {
-                jQuery('#checkoutdiv').addClass('loading');
-                jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
+            self.lock();
         });
         jQuery( document ).on('submit', 'div.woocommerce:not(.widget_product_search) > form', function() {
-                jQuery('#checkoutdiv').addClass('loading');
-                jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
+            self.lock();
         });
         jQuery( document ).on('click', 'a.woocommerce-remove-coupon', function() {
-                jQuery('#checkoutdiv').addClass('loading');
-                jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
+            self.lock();
         });
         jQuery( document ).on('click', 'td.product-remove > a', function() {
-                jQuery('#checkoutdiv').addClass('loading');
-                jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
+            self.lock();
         });
         jQuery( document ).on('change', 'select.shipping_method, input[name^=shipping_method]', function() {
-                jQuery('#checkoutdiv').addClass('loading');
-                jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
+            self.lock();
         });
 
         /* Updated cart totals */
@@ -180,26 +172,40 @@ var BillmateIframe = new function(){
 
     };
 
-    this.updateCheckout = function(){
+    this.checkoutPostMessage = function(message) {
         var win = document.getElementById('checkout').contentWindow;
-        win.postMessage(JSON.stringify({event: 'update_checkout'}),'*')
+        win.postMessage(message,'*')
+    }
+
+    this.updateCheckout = function(){
+        this.lock();
+        this.checkoutPostMessage('update');
+    }
+
+    this.lock = function() {
+        this.checkoutPostMessage('lock');
+    }
+
+    this.unlock = function() {
+        this.checkoutPostMessage('unlock');
     }
 
     var showCheckoutLoadingCounter = 0;
     this.showCheckoutLoading = function() {
-        showCheckoutLoadingCounter++;
-        jQuery('#checkoutdiv').addClass('loading');
-        jQuery("#checkoutdiv.loading .billmateoverlay").height(jQuery("#checkoutdiv").height());
-    }
-
-    this.hideCheckoutLoading = function() {
-        showCheckoutLoadingCounter--;
         if(showCheckoutLoadingCounter < 1) {
             showCheckoutLoadingCounter = 0;
         }
 
+        showCheckoutLoadingCounter++;
+        self.lock();
+    }
+
+    this.hideCheckoutLoading = function() {
+        showCheckoutLoadingCounter--;
+
         if(showCheckoutLoadingCounter < 1) {
-            jQuery('#checkoutdiv').removeClass('loading');
+            showCheckoutLoadingCounter = 0;
+            self.unlock();
         }
     }
 

--- a/woocommerce-gateway-billmate/shortcodes.php
+++ b/woocommerce-gateway-billmate/shortcodes.php
@@ -60,7 +60,7 @@ function get_billmate_checkout(){
         $wpLanguage = strtolower(current(explode('_',get_locale())));
 
         if($checkoutUrl != "") {
-		  return '<div id="checkoutdiv"><iframe id="checkout" src="' . $checkoutUrl . '" sandbox="allow-same-origin allow-scripts allow-modals allow-popups allow-forms allow-top-navigation" style="width:100%;min-height:800px;border:none;" scrolling="no"></iframe><div class="billmateoverlay"></div><div class="billmateloading"></div></div>';
+		  return '<div id="checkoutdiv"><iframe id="checkout" src="' . $checkoutUrl . '" sandbox="allow-same-origin allow-scripts allow-modals allow-popups allow-forms allow-top-navigation" style="width:100%;min-height:800px;border:none;" scrolling="no"></iframe>';
         } else {
             $checkoutError = $checkout->get_error();
             if($wpLanguage != "sv") {


### PR DESCRIPTION
* Fix - Bank payments now always use the same string where it's referenced.
* Fix - Rounding improvements. Under some rare circumstances the amount can be different from payment window to callback and/or accept url. 
* Enhancement - Improved loading animation for Checkout - The loading animation is more precise triggered when needed.
* Feature - Support for plugin "Product Add-Ons" in combination with Billmate Checkout.