### PR TITLE
Remove checked attribute to comply with GDPR

### DIFF
--- a/woocommerce-gateway-billmate/class-billmate-account.php
+++ b/woocommerce-gateway-billmate/class-billmate-account.php
@@ -928,7 +928,7 @@ parse_str($_POST['post_data'], $datatemp);
 ?>
 		<div class="clear"></div>
 			<p class="form-row">
-				<input type="checkbox" class="input-checkbox" checked="checked" value="yes" name="valid_email_it_is" id="valid_email_it_is" style="float:left;margin-top:6px" />
+				<input type="checkbox" class="input-checkbox" value="yes" name="valid_email_it_is" id="valid_email_it_is" style="float:left;margin-top:6px" />
 				<label><?php echo sprintf(__('My e-mail%s is correct och and may be used for billing. I confirm the ', 'billmate'), (strlen($datatemp['billing_email']) > 0) ? ', '.$datatemp['billing_email'].',' : ' '); ?><a class="billmateCheckoutTermLink" href="https://billmate.se/billmate/?cmd=villkor_delbetalning" onclick="window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=650');return false;"><?php echo __('terms of partpayment','billmate'); ?></a>, <a class="billmateCheckoutTermLink" href="https://www.billmate.se/integritetspolicy/" onclick="window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=650');return false;"><?php echo __('Privacy Policy','billmate'); ?></a> <?php echo __('and accept the liability.','billmate') ?></label>
 			</p>
 

--- a/woocommerce-gateway-billmate/class-billmate-invoice.php
+++ b/woocommerce-gateway-billmate/class-billmate-invoice.php
@@ -580,7 +580,7 @@ parse_str($_POST['post_data'], $datatemp);
 ?>
 		<div class="clear"></div>
 			<p class="form-row">
-				<input type="checkbox" class="input-checkbox" checked="checked" value="yes" name="valid_email_it_is_invoice" id="valid_email_it_is_invoice" style="float:left;margin-top:6px" />
+				<input type="checkbox" class="input-checkbox" value="yes" name="valid_email_it_is_invoice" id="valid_email_it_is_invoice" style="float:left;margin-top:6px" />
 				<label><?php echo sprintf(__('My e-mail%s is correct och and may be used for billing. I confirm the ', 'billmate'), (strlen($datatemp['billing_email']) > 0) ? ', '.$datatemp['billing_email'].',' : ' '); ?><a class="billmateCheckoutTermLink" href="https://billmate.se/billmate/?cmd=villkor" onclick="window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=650');return false;"><?php echo __('terms of invoice','billmate'); ?></a>, <a class="billmateCheckoutTermLink" href="https://www.billmate.se/integritetspolicy/" onclick="window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=650');return false;"><?php echo __('Privacy Policy','billmate'); ?></a> <?php echo __('and accept the liability.','billmate') ?></label>
 			</p>
 		<div class="clear"></div>


### PR DESCRIPTION
According to the new GDPR law in Europe terms checkboxes can't be preselected. An active user action needs to happen to accept terms.

This pull request removes the checked attribute from invoice checkout and account creation terms checkboxes.