### PR TITLE
Add trigger for getaddress error

### DIFF
--- a/woocommerce-gateway-billmate/js/billmatepopup.js
+++ b/woocommerce-gateway-billmate/js/billmatepopup.js
@@ -351,6 +351,7 @@ AddEvent(window,'load',function(){
                     var message = '<div id="getaddresserror" class="woocommerce-error">'+result.message+'</div>';
                     $('#getaddresserr').html(message);
                     $('[name="pno"]').parent('p').removeClass('woocommerce-validated').addClass('woocommerce-invalid woocommerce-invalid-required-field');
+                    $('body').trigger('getaddresserror');
                 }
             }
         })


### PR DESCRIPTION
When doing a get adress call there is only a trigger if the jQuery POST is successful. 

If you, for example, add a loading animation when the get adress function is running there is no easy way to react on a fail. That may happen if the org.nr is incorrect or the request times out.

This pull request adds a trigger (getaddresserror) that you can listen for in your own code.