### PR TITLE
Remove utf8_decoding in Billmate Checkout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.4.8 (2019-09-02)
+  * Fix - E-mails purchased through Billmate Checkout have the correct encoding.
+
 ## 3.4.7 (2019-07-15)
   * Fix - WhooCommerce built-in checkout use Billmates new logos
   * Fix WhooCommerce shows correct company delivery address

--- a/woocommerce-gateway-billmate/Readme.txt
+++ b/woocommerce-gateway-billmate/Readme.txt
@@ -89,6 +89,9 @@ If you would like to use our logo on your site then choose following:
 
 == Changelog ==
 
+= 3.4.8 (2019-09-92)
+  * Fix - E-mails purchased through Billmate Checkout have the correct encoding.
+  
 = 3.4.7 (2019-07-15)
   * Fix - WhooCommerce built-in checkout use Billmates new logos
   * Fix WhooCommerce shows correct company delivery address

--- a/woocommerce-gateway-billmate/Readme.txt
+++ b/woocommerce-gateway-billmate/Readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: woocomerce, billmate, payments, cardpayments, invoice, partpayment, recurring, bankpayment
 Requires at least: 4.0
 Tested up to: 5.2.2
-Stable tag: 3.4.7
+Stable tag: 3.4.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 WC tested up to: 3.6.5

--- a/woocommerce-gateway-billmate/commonfunctions.php
+++ b/woocommerce-gateway-billmate/commonfunctions.php
@@ -1,5 +1,5 @@
 <?php
-define('BILLPLUGIN_VERSION','3.4.7');
+define('BILLPLUGIN_VERSION','3.4.8');
 define('BILLMATE_CLIENT','PHP:Woocommerce:'.BILLPLUGIN_VERSION);
 define('BILLMATE_SERVER','2.1.9');
 

--- a/woocommerce-gateway-billmate/gateway-billmate.php
+++ b/woocommerce-gateway-billmate/gateway-billmate.php
@@ -3,7 +3,7 @@
 Plugin Name: WooCommerce Billmate Gateway
 Plugin URI: http://woothemes.com/woocommerce
 Description: Receive payments on your WooCommerce store via Billmate. Invoice, partpayment, credit/debit card and direct bank transfers. Secure and 100&#37; free plugin.
-Version: 3.4.7
+Version: 3.4.8
 Author: Billmate
 Text Domain: billmate
 Author URI: https://billmate.se

--- a/woocommerce-gateway-billmate/gateway-billmate.php
+++ b/woocommerce-gateway-billmate/gateway-billmate.php
@@ -753,14 +753,7 @@ function init_billmate_gateway() {
                             && is_array($billmateOrder['Customer'])
                             && count($billmateOrder['Customer']) > 0
                     ) {
-                        if (isset($billmateOrder['Customer']['Billing'])) {
-                            $billmateOrder['Customer']['Billing'] = array_map("utf8_decode",$billmateOrder['Customer']['Billing']);
-                        }
-
-                        if (isset($billmateOrder['Customer']['Shipping'])) {
-                            $billmateOrder['Customer']['Shipping'] = array_map("utf8_decode",$billmateOrder['Customer']['Shipping']);
-                        }
-
+                     
                         $billing_address = array(
                             'first_name' => $billmateOrder['Customer']['Billing']['firstname'],
                             'last_name'  => $billmateOrder['Customer']['Billing']['lastname'],


### PR DESCRIPTION
Deleted utf8-ecoding in the file as it is now managed instead in getPaymentInfo API. 